### PR TITLE
Updated a ubuntu package repository.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Ubuntu 12.04 LTS and Python 2.4, 2.5, 2.6, 2.7, 3.1, 3.2, 3.3, pypy
 FROM ubuntu:12.04
 MAINTAINER Takayuki SHIMIZUKAWA "shimizukawa@gmail.com"
+RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
+RUN apt-get update
 RUN apt-get install -qq -y python-software-properties
 RUN add-apt-repository ppa:fkrull/deadsnakes
 RUN add-apt-repository ppa:pypy/ppa

--- a/python-all-dev/Dockerfile
+++ b/python-all-dev/Dockerfile
@@ -1,6 +1,8 @@
 # Ubuntu 12.04 LTS and Python-dev package for 2.4, 2.5, 2.6, 2.7, 3.1, 3.2, 3.3, pypy
 FROM shimizukawa/python-all
 MAINTAINER Takayuki SHIMIZUKAWA "shimizukawa@gmail.com"
+RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
+RUN apt-get update
 RUN apt-get install -qq -y \
     python2.4-dev \
     python2.5-dev \


### PR DESCRIPTION
Failed to build cause the ubuntu package repository is up to dated.

```
docker build github.com/shimizukawa/docker-python-all
Step 0 : FROM ubuntu:12.04
 ---> 9cd978db300e
Step 1 : MAINTAINER Takayuki SHIMIZUKAWA "shimizukawa@gmail.com"
 ---> Using cache
 ---> d36ebe408e11
Step 2 : RUN apt-get install -qq -y python-software-properties
 ---> Running in b1a0341f5b0f
Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/curl/libcurl3-gnutls_7.22.0-3ubuntu4.6_amd64.deb  404  Not Found [IP: 91.189.91.15 80]
Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt-common_0.8.3ubuntu7.1_all.deb  404  Not Found [IP: 91.189.91.15 80]
Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_0.8.3ubuntu7.1_amd64.deb  404  Not Found [IP: 91.189.91.15 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
2014/02/09 16:21:58 build: The command [/bin/sh -c apt-get install -qq -y python-software-properties] returned a non-zero code: 100
```
